### PR TITLE
Remove annoying println!(), probably left behind for debugging

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -132,7 +132,6 @@ impl serde::Deserializer for Decoder {
 
     fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Self::Error>
     where V: serde::de::Visitor {
-        println!("visit {:?}", self.data);
         match self.data.pop() {
             Some(Data::Null) => visitor.visit_unit(),
             Some(Data::Bool(b)) => visitor.visit_bool(b),


### PR DESCRIPTION
The `println!()` makes the crate a bit annoying to use. Alternatively if the output is required, maybe the [log](https://crates.io/crates/log/) crate (possibly combined with [env-logger](https://crates.io/crates/env_logger/) in `dev-dependencies`) would be a better fit.